### PR TITLE
Fix spelling mistake in color utility page.

### DIFF
--- a/docs/utilities.colors.html
+++ b/docs/utilities.colors.html
@@ -34,7 +34,7 @@
       </div>
 
       <h1>Color utilities</h1>
-      <p class="is-lead">Do-Design provides a powerful and functional color system. All colors can be overriden in the "_child.scss" file.</p>
+      <p class="is-lead">Co-Design provides a powerful and functional color system. All colors can be overriden in the "_child.scss" file.</p>
 
       <h2 id="primary-color">Primary color</h2>
 


### PR DESCRIPTION
There's a spelling mistake on the Utilities > Colors page. This PR changes "Do-Design" to proper "Co-Design". 

Thanks to @cellio for spotting this. :)