### PR TITLE
#51 Close droppanel and header panel on close

### DIFF
--- a/docs/js/co-design.js
+++ b/docs/js/co-design.js
@@ -127,10 +127,12 @@
             function HeaderSlideToggle(element) {
                 var _this = this;
                 this.element = element;
+                this.slideTriggerNode = element;
                 this.refersToElement = document.querySelector(element.getAttribute("data-header-slide"));
                 if (this.refersToElement == null) {
                     throw "Missing target for dismiss: " + element.getAttribute("data-dismiss");
                 }
+                this.closeSlideOnClickOutside();
                 element.addEventListener("click", function (e) { _this.toggle(); e.preventDefault(); });
             }
             HeaderSlideToggle.prototype.toggle = function () {
@@ -158,6 +160,22 @@
                     this.refersToElement.style.maxWidth = "100%";
                 }
             };
+            HeaderSlideToggle.prototype.closeSlide = function () {
+                this.refersToElement.classList.remove("is-active");
+                this.element.classList.remove("is-active");
+            };
+            HeaderSlideToggle.prototype.closeSlideOnClickOutside = function () {
+                var _this = this;
+                var slideSelector = this.slideTriggerNode.getAttribute("data-header-slide");
+                document.addEventListener("click", function (e) {
+                    var target = e.target;
+                    var parentSlide = target.closest(slideSelector);
+                    if (parentSlide !== _this.refersToElement && _this.slideTriggerNode !== target) {
+                        _this.closeSlide();
+                        e.preventDefault();
+                    }
+                });
+            };
             HeaderSlideToggle.find = function (container, query) {
                 var elements = container.querySelectorAll(query);
                 var headerslidetoggles = [];
@@ -178,12 +196,14 @@
             function DropPanel(element) {
                 var _this = this;
                 this.element = element;
+                this.panelTriggerNode = element;
                 this.refersToElement = document.querySelector(element.getAttribute("data-drop"));
                 if (this.refersToElement == null) {
                     throw "Missing target for DropPanel: " + element.getAttribute("data-drop");
                 }
                 this.elementActiveClass = element.hasAttribute("data-drop-self-class-toggle") ? element.getAttribute("data-drop-self-class-toggle") : null;
                 this.forcedDirection = element.hasAttribute("data-drop-force-dir") ? element.getAttribute("data-drop-force-dir") : null;
+                this.closePanelOnClickOutside();
                 element.addEventListener("click", function (e) { _this.toggleDropPanel(); e.preventDefault(); });
             }
             DropPanel.prototype.toggleDropPanel = function () {
@@ -228,6 +248,24 @@
                     else {
                         this.refersToElement.style.bottom = (window.innerHeight - window.scrollY - rect.top + DropPanel.offsetInPixel) + "px";
                     }
+                }
+            };
+            DropPanel.prototype.closePanelOnClickOutside = function () {
+                var _this = this;
+                var dropPanelSelector = this.panelTriggerNode.getAttribute("data-drop");
+                document.addEventListener("click", function (e) {
+                    var target = e.target;
+                    var parentDropdown = target.closest(dropPanelSelector);
+                    if (parentDropdown !== _this.refersToElement && _this.panelTriggerNode !== target) {
+                        _this.closeDropPanel();
+                        e.preventDefault();
+                    }
+                });
+            };
+            DropPanel.prototype.closeDropPanel = function () {
+                this.refersToElement.classList.remove("is-active");
+                if (this.elementActiveClass) {
+                    this.element.classList.remove(this.elementActiveClass);
                 }
             };
             DropPanel.find = function (query) {

--- a/js/co-design.js
+++ b/js/co-design.js
@@ -127,10 +127,12 @@
             function HeaderSlideToggle(element) {
                 var _this = this;
                 this.element = element;
+                this.slideTriggerNode = element;
                 this.refersToElement = document.querySelector(element.getAttribute("data-header-slide"));
                 if (this.refersToElement == null) {
                     throw "Missing target for dismiss: " + element.getAttribute("data-dismiss");
                 }
+                this.closeSlideOnClickOutside();
                 element.addEventListener("click", function (e) { _this.toggle(); e.preventDefault(); });
             }
             HeaderSlideToggle.prototype.toggle = function () {
@@ -158,6 +160,22 @@
                     this.refersToElement.style.maxWidth = "100%";
                 }
             };
+            HeaderSlideToggle.prototype.closeSlide = function () {
+                this.refersToElement.classList.remove("is-active");
+                this.element.classList.remove("is-active");
+            };
+            HeaderSlideToggle.prototype.closeSlideOnClickOutside = function () {
+                var _this = this;
+                var slideSelector = this.slideTriggerNode.getAttribute("data-header-slide");
+                document.addEventListener("click", function (e) {
+                    var target = e.target;
+                    var parentSlide = target.closest(slideSelector);
+                    if (parentSlide !== _this.refersToElement && _this.slideTriggerNode !== target) {
+                        _this.closeSlide();
+                        e.preventDefault();
+                    }
+                });
+            };
             HeaderSlideToggle.find = function (container, query) {
                 var elements = container.querySelectorAll(query);
                 var headerslidetoggles = [];
@@ -178,12 +196,14 @@
             function DropPanel(element) {
                 var _this = this;
                 this.element = element;
+                this.panelTriggerNode = element;
                 this.refersToElement = document.querySelector(element.getAttribute("data-drop"));
                 if (this.refersToElement == null) {
                     throw "Missing target for DropPanel: " + element.getAttribute("data-drop");
                 }
                 this.elementActiveClass = element.hasAttribute("data-drop-self-class-toggle") ? element.getAttribute("data-drop-self-class-toggle") : null;
                 this.forcedDirection = element.hasAttribute("data-drop-force-dir") ? element.getAttribute("data-drop-force-dir") : null;
+                this.closePanelOnClickOutside();
                 element.addEventListener("click", function (e) { _this.toggleDropPanel(); e.preventDefault(); });
             }
             DropPanel.prototype.toggleDropPanel = function () {
@@ -228,6 +248,24 @@
                     else {
                         this.refersToElement.style.bottom = (window.innerHeight - window.scrollY - rect.top + DropPanel.offsetInPixel) + "px";
                     }
+                }
+            };
+            DropPanel.prototype.closePanelOnClickOutside = function () {
+                var _this = this;
+                var dropPanelSelector = this.panelTriggerNode.getAttribute("data-drop");
+                document.addEventListener("click", function (e) {
+                    var target = e.target;
+                    var parentDropdown = target.closest(dropPanelSelector);
+                    if (parentDropdown !== _this.refersToElement && _this.panelTriggerNode !== target) {
+                        _this.closeDropPanel();
+                        e.preventDefault();
+                    }
+                });
+            };
+            DropPanel.prototype.closeDropPanel = function () {
+                this.refersToElement.classList.remove("is-active");
+                if (this.elementActiveClass) {
+                    this.element.classList.remove(this.elementActiveClass);
                 }
             };
             DropPanel.find = function (query) {

--- a/js_src/droppanel.ts
+++ b/js_src/droppanel.ts
@@ -2,10 +2,12 @@ export default class DropPanel {
     private readonly refersToElement: HTMLElement;
     private readonly elementActiveClass: string;
     private readonly forcedDirection: string;
+    private readonly panelTriggerNode: HTMLElement;
 
     public static offsetInPixel: number = 2;
 
     constructor(public readonly element: HTMLElement) {
+        this.panelTriggerNode = element;
         this.refersToElement = document.querySelector(element.getAttribute("data-drop"));
 
         if (this.refersToElement == null) {
@@ -14,7 +16,8 @@ export default class DropPanel {
 
         this.elementActiveClass = element.hasAttribute("data-drop-self-class-toggle") ? element.getAttribute("data-drop-self-class-toggle") : null;
         this.forcedDirection = element.hasAttribute("data-drop-force-dir") ? element.getAttribute("data-drop-force-dir") : null;
-
+        
+        this.closePanelOnClickOutside();
         element.addEventListener("click", (e) => { this.toggleDropPanel(); e.preventDefault(); });
     }
 
@@ -71,6 +74,25 @@ export default class DropPanel {
             } else {
                 this.refersToElement.style.bottom = (window.innerHeight - window.scrollY - rect.top + DropPanel.offsetInPixel) + "px";
             }
+        }
+    }
+
+    private closePanelOnClickOutside() {
+        const dropPanelSelector = this.panelTriggerNode.getAttribute("data-drop");
+        document.addEventListener("click", (e) => {
+            const target = e.target as HTMLElement;
+            const parentDropdown = target.closest(dropPanelSelector);
+            if(parentDropdown !== this.refersToElement && this.panelTriggerNode !== target) {
+                this.closeDropPanel();
+                e.preventDefault();
+            }
+        });
+    }
+
+    private closeDropPanel() {
+        this.refersToElement.classList.remove("is-active");
+        if (this.elementActiveClass) {
+            this.element.classList.remove(this.elementActiveClass);
         }
     }
     

--- a/js_src/header.ts
+++ b/js_src/header.ts
@@ -15,14 +15,17 @@ export default class Header {
 
 export class HeaderSlideToggle {
     private readonly refersToElement: HTMLElement;
+    private readonly slideTriggerNode: HTMLElement;
 
     constructor(public readonly element: HTMLElement) {
+        this.slideTriggerNode = element;
         this.refersToElement = document.querySelector(element.getAttribute("data-header-slide"));
 
         if (this.refersToElement == null) {
             throw "Missing target for dismiss: " + element.getAttribute("data-dismiss");
         }
         
+        this.closeSlideOnClickOutside();
         element.addEventListener("click", (e) => { this.toggle(); e.preventDefault(); });
     }
 
@@ -58,6 +61,23 @@ export class HeaderSlideToggle {
             this.refersToElement.style.right = "0px";
             this.refersToElement.style.maxWidth = "100%";
         }
+    }
+
+    private closeSlide() {
+        this.refersToElement.classList.remove("is-active");
+        this.element.classList.remove("is-active");
+    }
+
+    private closeSlideOnClickOutside() {
+        const slideSelector = this.slideTriggerNode.getAttribute("data-header-slide");
+        document.addEventListener("click", (e) => {
+            const target = e.target as HTMLElement;
+            const parentSlide = target.closest(slideSelector);
+            if(parentSlide !== this.refersToElement && this.slideTriggerNode !== target) {
+                this.closeSlide();
+                e.preventDefault();
+            }
+        });
     }
     
     static find(container: HTMLElement, query: string) {


### PR DESCRIPTION
Fixes #51 
Addresses an issue where toggled panels could layer up by only being closed by its toggle element.
All panels will now close when clicked outside of its own panel, or on the toggle itself.