### PR TITLE
tripled height of code blocks (issue #43)

### DIFF
--- a/src/common/_config.scss
+++ b/src/common/_config.scss
@@ -89,7 +89,7 @@ $code-padding-y: 0.5 !default;
 $code-padding-x: 1 !default;
 
 $code-block-padding: 2 !default;
-$code-block-max-height: 20em !default;
+$code-block-max-height: 60em !default;
 
 $quote-margin-y: 1 !default;
 $quote-margin-x: 0 !default;


### PR DESCRIPTION
Code blocks currently show only 13 lines, which isn't enough.  Discussion on the linked issue suggests 40 as a reasonable number.  A comment from @luap42 (https://github.com/codidact/co-design/issues/43#issuecomment-719469207) points to the line to change; it's measured in ems not lines, so I tripled it from 20 to 60, preferring the round number in the CSS to the round number of 40 lines.

I can't test this.  Please review.
