### PR TITLE
Update docs version label

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
                 </div>
                 <div class="spacer"></div>
                 <div class="vinfo">
-                    <div class="entry">version: 0.12.3</div>
+                    <div class="entry">version: 0.12.5</div>
                     <div class="entry">hosted: <a href="https://github.com/Codidact/Co-Design">on Github</a></div>
                     <div class="entry">open-source: <a href="https://choosealicense.com/licenses/mit/">MIT license</a></div>
                 </div>


### PR DESCRIPTION
This PR follows on from PR #67, which was automatically closed by GitHub when I was trying to modify some things.

Please see previous PR for context. The only change made here (compared to previous PR) is changing the version tags to 0.12.5 instead of 0.12.4 and otherwise applying the release process on the same basis as it was previously.